### PR TITLE
fix typo in logo link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ show_sidebar: true                # Show the sidebar. Only set to false if your 
 collapse_inactive_chapters: true  # Whether to collapse the inactive chapters in the sidebar
 collapse_inactive_sections: true  # Whether to collapse the sub-sections within a non-active section in the sidebar
 textbook_logo: images/logo/logo.png               # A logo to be displayed at the top of your textbook sidebar. Should be square
-textbook_logo_link: hhttps://sherbold.github.io/intro-to-data-science                    # A link for the logo.
+textbook_logo_link: https://sherbold.github.io/intro-to-data-science                    # A link for the logo.
 sidebar_footer_text: Powered by <a href="https://jupyterbook.org">Jupyter Book</a>
 number_toc_chapters: true         # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml
 


### PR DESCRIPTION
When clicking on the logo in the top left corner of the website you don't get redirected back to the homepage because of a typo in the address. This pull request should fix the issue.