### PR TITLE
Fix the output of the variability measures example

### DIFF
--- a/_build/03_Data-Exploration.html
+++ b/_build/03_Data-Exploration.html
@@ -284,8 +284,8 @@ where $Q_{upper}$ is the upper quartile and $Q_{lower}$ is the lower quartile. T
 
 <span class="n">data</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="mi">100</span><span class="p">)</span>
 <span class="nb">print</span><span class="p">(</span><span class="s1">&#39;With outlier&#39;</span><span class="p">)</span>
-<span class="nb">print</span><span class="p">(</span><span class="s1">&#39;mean:  &#39;</span><span class="p">,</span> <span class="n">statistics</span><span class="o">.</span><span class="n">stdev</span><span class="p">(</span><span class="n">data</span><span class="p">))</span>
-<span class="nb">print</span><span class="p">(</span><span class="s1">&#39;median:&#39;</span><span class="p">,</span> <span class="n">stats</span><span class="o">.</span><span class="n">iqr</span><span class="p">(</span><span class="n">data</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">(</span><span class="s1">&#39;sd: &#39;</span><span class="p">,</span> <span class="n">statistics</span><span class="o">.</span><span class="n">stdev</span><span class="p">(</span><span class="n">data</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">(</span><span class="s1">&#39;IQR:&#39;</span><span class="p">,</span> <span class="n">stats</span><span class="o">.</span><span class="n">iqr</span><span class="p">(</span><span class="n">data</span><span class="p">))</span>
 </pre></div>
 
     </div>
@@ -303,8 +303,8 @@ where $Q_{upper}$ is the upper quartile and $Q_{lower}$ is the lower quartile. T
 sd:  2.031568135925815
 IQR: 2.255000000000001
 With outlier
-mean:   26.77235292350312
-median: 2.465
+sd:  26.77235292350312
+IQR: 2.465
 </pre>
 </div>
 </div>

--- a/content/03_Data-Exploration.ipynb
+++ b/content/03_Data-Exploration.ipynb
@@ -211,8 +211,8 @@
       "sd:  2.031568135925815\n",
       "IQR: 2.255000000000001\n",
       "With outlier\n",
-      "mean:   26.77235292350312\n",
-      "median: 2.465\n"
+      "sd:  26.77235292350312\n",
+      "IQR: 2.465\n"
      ]
     }
    ],
@@ -226,8 +226,8 @@
     "\n",
     "data.append(100)\n",
     "print('With outlier')\n",
-    "print('mean:  ', statistics.stdev(data))\n",
-    "print('median:', stats.iqr(data))"
+    "print('sd: ', statistics.stdev(data))\n",
+    "print('IQR:', stats.iqr(data))"
    ]
   },
   {


### PR DESCRIPTION
The example for the variability measures with outliers in chapter three prints 'mean' and 'median' instead of 'standard deviation' and 'interquartile range'.